### PR TITLE
chore: extract magic constants into named constants

### DIFF
--- a/lib/src/services/advertising_id_service.dart
+++ b/lib/src/services/advertising_id_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart' show MethodChannel;
 import 'package:kontext_flutter_sdk/src/services/logger.dart';
 import 'package:kontext_flutter_sdk/src/services/tracking_authorization_service.dart';
+import 'package:kontext_flutter_sdk/src/utils/constants.dart';
 import 'package:kontext_flutter_sdk/src/utils/extensions.dart';
 
 class AdvertisingIdService {
@@ -137,14 +138,14 @@ class AdvertisingIdService {
     final major = int.tryParse(parts[0]) ?? 0;
     final minor = parts.length > 1 ? int.tryParse(parts[1]) ?? 0 : 0;
 
-    if (major > 14) {
+    if (major > kMinAttIosMajorVersion) {
       return true;
     }
-    if (major < 14) {
+    if (major < kMinAttIosMajorVersion) {
       return false;
     }
 
-    return minor >= 5;
+    return minor >= kMinAttIosMinorVersion;
   }
 
   static bool _isIOS() => Platform.isIOS;

--- a/lib/src/services/http_client.dart
+++ b/lib/src/services/http_client.dart
@@ -24,7 +24,7 @@ class HttpClient {
 
   Future<({http.Response response, Json data})> post(
     String path, {
-    Duration timeout = const Duration(seconds: 60),
+    Duration timeout = const Duration(seconds: kHttpTimeoutSeconds),
     Json? body,
     Json? headers,
   }) async {

--- a/lib/src/services/logger.dart
+++ b/lib/src/services/logger.dart
@@ -1,6 +1,7 @@
 import 'dart:developer' as developer;
 import 'package:flutter/foundation.dart';
 import 'package:kontext_flutter_sdk/src/services/http_client.dart';
+import 'package:kontext_flutter_sdk/src/utils/constants.dart';
 import 'package:kontext_flutter_sdk/src/utils/types.dart' show Json;
 
 /// Log levels for the logger.
@@ -116,7 +117,7 @@ class Logger {
 
     developer.log(
       message,
-      name: 'Kontext',
+      name: kLoggerName,
       level: level.developerLogLevel,
       error: error,
       stackTrace: stackTrace,
@@ -138,8 +139,8 @@ class Logger {
       if (kDebugMode) {
         developer.log(
           'Failed to log to remote: $e',
-          name: 'Kontext',
-          level: 1000,
+          name: kLoggerName,
+          level: LogLevel.error.developerLogLevel,
         );
       }
     }
@@ -156,8 +157,8 @@ class Logger {
       if (kDebugMode) {
         developer.log(
           'Failed to log exception to remote: $e',
-          name: 'Kontext',
-          level: 1000,
+          name: kLoggerName,
+          level: LogLevel.error.developerLogLevel,
         );
       }
     }

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -1,3 +1,26 @@
 const kDefaultAdServerUrl = 'https://server.megabrain.co';
 const kSdkLabel = 'sdk-flutter';
 const kSdkVersion = '2.2.2';
+
+// HTTP
+const kHttpTimeoutSeconds = 60;
+
+// Messaging
+const kMaxMessageHistory = 30;
+
+// Animations
+const kInterstitialFadeDurationMs = 300;
+
+// Ad dimension polling
+const kAdDimensionInitialDelayMs = 500;
+const kAdDimensionIntervalMs = 300;
+
+// ATT (App Tracking Transparency) minimum iOS version (14.5)
+const kMinAttIosMajorVersion = 14;
+const kMinAttIosMinorVersion = 5;
+
+// SKAdNetwork
+const kSkanFidelityFull = 1;
+
+// Logger
+const kLoggerName = 'Kontext';

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_inappwebview/flutter_inappwebview.dart'
     show ChromeSafariBrowser, WebUri, ChromeSafariBrowserSettings;
 import 'package:kontext_flutter_sdk/src/services/logger.dart';
+import 'package:kontext_flutter_sdk/src/utils/constants.dart';
 import 'package:kontext_flutter_sdk/src/utils/helper_methods.dart';
 import 'package:kontext_flutter_sdk/src/models/message.dart';
 
@@ -29,7 +30,7 @@ extension ListExtension<E> on List<E> {
 }
 
 extension MessageListExtension on List<Message> {
-  List<Message> getLastMessages({int count = 30}) {
+  List<Message> getLastMessages({int count = kMaxMessageHistory}) {
     return length > count ? sublist(length - count) : this;
   }
 }

--- a/lib/src/widgets/ad_format.dart
+++ b/lib/src/widgets/ad_format.dart
@@ -243,7 +243,7 @@ class AdFormat extends HookWidget {
       // Check if bid has fidelity-1 SKAN data for StoreKit-rendered attribution.
       // If so, we open SKStoreProductViewController instead of the browser.
       final skan = bid.skan;
-      final hasFidelity1 = skan != null && (skan.fidelities?.any((f) => f.fidelity == 1) ?? false);
+      final hasFidelity1 = skan != null && (skan.fidelities?.any((f) => f.fidelity == kSkanFidelityFull) ?? false);
 
       if (hasFidelity1) {
         final storeProductOpened = await _presentSkStoreProduct(skan);
@@ -291,7 +291,7 @@ class AdFormat extends HookWidget {
   Future<bool> _presentSkOverlay(Json data, Skan? skan) async {
     // SKOverlay requires fidelity-1 SKAN data for attribution.
     // Without it there's no point opening the overlay.
-    final hasFidelity1 = skan != null && (skan.fidelities?.any((f) => f.fidelity == 1) ?? false);
+    final hasFidelity1 = skan != null && (skan.fidelities?.any((f) => f.fidelity == kSkanFidelityFull) ?? false);
     if (!hasFidelity1) {
       Logger.error('SKOverlay requires fidelity-1 SKAN data. Skipping.');
       return false;
@@ -557,7 +557,7 @@ class AdFormat extends HookWidget {
       final shouldRun = iframeLoaded.value && showIframe.value;
       if (shouldRun && ticker.value == null && delayedTicker.value == null) {
         // Start after a short delay to allow initial layout to settle
-        delayedTicker.value = Timer(const Duration(milliseconds: 500), () {
+        delayedTicker.value = Timer(const Duration(milliseconds: kAdDimensionInitialDelayMs), () {
           delayedTicker.value = null;
           if (!iframeLoaded.value || !showIframe.value || disposed.value) {
             return;
@@ -565,7 +565,7 @@ class AdFormat extends HookWidget {
           // First call immediately without waiting for the first tick
           postDimensions();
           ticker.value = Timer.periodic(
-            const Duration(milliseconds: 300),
+            const Duration(milliseconds: kAdDimensionIntervalMs),
             (_) => postDimensions(),
           );
         });

--- a/lib/src/widgets/interstitial_modal.dart
+++ b/lib/src/widgets/interstitial_modal.dart
@@ -2,6 +2,7 @@ import 'dart:async' show Timer;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show DeviceOrientation, SystemChrome;
+import 'package:kontext_flutter_sdk/src/utils/constants.dart';
 import 'package:kontext_flutter_sdk/src/utils/types.dart' show Json, OpenIframeComponent;
 import 'package:kontext_flutter_sdk/src/widgets/kontext_webview.dart';
 
@@ -71,7 +72,7 @@ class InterstitialModal {
               child: AnimatedOpacity(
                 key: animatedOpacityKey,
                 opacity: isVisible ? 1.0 : 0.0,
-                duration: const Duration(milliseconds: 300),
+                duration: const Duration(milliseconds: kInterstitialFadeDurationMs),
                 curve: Curves.easeInOut,
                 child: SizedBox(
                   width: double.infinity,


### PR DESCRIPTION
## Summary

- Adds named constants to `lib/src/utils/constants.dart` for all previously hardcoded values
- Replaces magic numbers/strings across 6 files with the named constants

### Constants added

| Constant | Value | Used in |
|---|---|---|
| `kHttpTimeoutSeconds` | `60` | `http_client.dart` |
| `kMaxMessageHistory` | `30` | `extensions.dart` |
| `kInterstitialFadeDurationMs` | `300` | `interstitial_modal.dart` |
| `kAdDimensionInitialDelayMs` | `500` | `ad_format.dart` |
| `kAdDimensionIntervalMs` | `300` | `ad_format.dart` |
| `kMinAttIosMajorVersion` | `14` | `advertising_id_service.dart` |
| `kMinAttIosMinorVersion` | `5` | `advertising_id_service.dart` |
| `kSkanFidelityFull` | `1` | `ad_format.dart` |
| `kLoggerName` | `'Kontext'` | `logger.dart` |

The two hardcoded `level: 1000` fallback log calls in `logger.dart` now use `LogLevel.error.developerLogLevel` to stay in sync with the enum definition.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test ./test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)