### PR TITLE
Suppress ERR_BLOCKED_BY_ORB noise from third-party ad creatives

### DIFF
--- a/lib/src/widgets/kontext_webview.dart
+++ b/lib/src/widgets/kontext_webview.dart
@@ -177,12 +177,6 @@ class KontextWebview extends HookWidget {
 
         switch (level) {
           case ConsoleMessageLevel.ERROR:
-            // ERR_BLOCKED_BY_ORB errors are caused by third-party ad creatives
-            // loading cross-origin resources without proper CORS headers.
-            // They are not actionable on our side, so we suppress them.
-            if (consoleMessage.message.contains('ERR_BLOCKED_BY_ORB')) {
-              return;
-            }
             _logError(
               webViewConsoleErrorLimiter,
               message: webViewMessage,

--- a/lib/src/widgets/kontext_webview.dart
+++ b/lib/src/widgets/kontext_webview.dart
@@ -177,6 +177,12 @@ class KontextWebview extends HookWidget {
 
         switch (level) {
           case ConsoleMessageLevel.ERROR:
+            // ERR_BLOCKED_BY_ORB errors are caused by third-party ad creatives
+            // loading cross-origin resources without proper CORS headers.
+            // They are not actionable on our side, so we suppress them.
+            if (consoleMessage.message.contains('ERR_BLOCKED_BY_ORB')) {
+              return;
+            }
             _logError(
               webViewConsoleErrorLimiter,
               message: webViewMessage,
@@ -190,6 +196,12 @@ class KontextWebview extends HookWidget {
         }
       },
       onReceivedError: (controller, request, error) {
+        // ERR_BLOCKED_BY_ORB errors are caused by third-party ad creatives
+        // loading cross-origin resources without proper CORS headers.
+        // They are not actionable on our side, so we suppress them.
+        if (error.description.contains('ERR_BLOCKED_BY_ORB')) {
+          return;
+        }
         final webViewMessage = 'Error received in InAppWebView: $error, request: $request';
         _logError(
           webViewConsoleErrorLimiter,


### PR DESCRIPTION
## Summary
- Suppress `ERR_BLOCKED_BY_ORB` errors in `onConsoleMessage` and `onReceivedError` WebView callbacks
- These errors are triggered by cross-origin resource requests from third-party ad creatives that lack proper CORS headers — not actionable on our side
- Reduces noise in logs and Sentry

Fixes [KON-1264](https://linear.app/kontext/issue/KON-1264)

🤖 Generated with [Claude Code](https://claude.com/claude-code)